### PR TITLE
Make highlighting of selected terms override research restoring if selected terms are found

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -46,7 +46,7 @@ const loadOptions = (() => {
 	const fillAndInsertStylesheet = () => {
 		const style = document.createElement("style");
 		style.textContent = `
-body { background-color: #bbb; }
+body { padding: 6px; margin: 0; background: #bbb; }
 .${OptionClass.ERRONEOUS} { color: #e11; }
 .${OptionClass.MODIFIED} { font-weight: bold; }
 .${OptionClass.TAB_BUTTON} { border-radius: 0; display: none; }

--- a/src/shared-content.ts
+++ b/src/shared-content.ts
@@ -141,6 +141,9 @@ class Engine {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface HighlightMessage {
+	getDetails?: {
+		termsFromSelection?: boolean
+	}
 	command?: CommandInfo
 	extensionCommands?: Array<chrome.commands.Command>
 	terms?: MatchTerms
@@ -154,6 +157,11 @@ interface HighlightMessage {
 	barLook?: StorageSyncValues[StorageSync.BAR_LOOK]
 	highlightLook?: StorageSyncValues[StorageSync.HIGHLIGHT_LOOK]
 	matchMode?: StorageSyncValues[StorageSync.MATCH_MODE_DEFAULTS]
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface HighlightDetails {
+	terms?: MatchTerms
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/term-highlight.ts
+++ b/src/term-highlight.ts
@@ -1475,20 +1475,8 @@ const beginHighlighting = (
 ) => {
 	highlightInNodesOnMutationDisconnect(observer);
 	if (termsFromSelection) {
-		const selection = document.getSelection();
 		terms = [];
-		if (selection && selection.anchorNode) {
-			const termsAll = selection.toString().split(" ").map(phrase => phrase.replace(/\W/g, ""))
-				.filter(phrase => phrase !== "").map(phrase => new MatchTerm(phrase));
-			const termSelectors: Set<string> = new Set;
-			termsAll.forEach(term => {
-				if (!termSelectors.has(term.selector)) {
-					termSelectors.add(term.selector);
-					terms.push(term);
-				}
-			});
-			selection.collapseToStart();
-		}
+		getTermsFromSelection().forEach(term => terms.push(term));
 		chrome.runtime.sendMessage({
 			terms,
 			makeUnique: true,
@@ -1503,6 +1491,24 @@ const beginHighlighting = (
 		terms.forEach(term => updateTermOccurringStatus(term));
 		highlightInNodesOnMutation(observer);
 	}
+};
+
+// TODO document
+const getTermsFromSelection = () => {
+	const selection = document.getSelection();
+	const terms: MatchTerms = [];
+	if (selection && selection.anchorNode) {
+		const termsAll = selection.toString().split(" ").map(phrase => phrase.replace(/\W/g, ""))
+			.filter(phrase => phrase !== "").map(phrase => new MatchTerm(phrase));
+		const termSelectors: Set<string> = new Set;
+		termsAll.forEach(term => {
+			if (!termSelectors.has(term.selector)) {
+				termSelectors.add(term.selector);
+				terms.push(term);
+			}
+		});
+	}
+	return terms;
 };
 
 (() => {
@@ -1748,7 +1754,14 @@ const beginHighlighting = (
 		const observer = getObserverNodeHighlighter(requestRefreshIndicators, highlightTags, terms);
 		produceEffectOnCommand.next(); // Requires an initial empty call before working (TODO otherwise mitigate)
 		insertStyleElement();
-		chrome.runtime.onMessage.addListener((message: HighlightMessage, sender, sendResponse) => {
+		chrome.runtime.onMessage.addListener((message: HighlightMessage, sender,
+			sendResponse: (response: HighlightDetails) => void) => {
+			if (message.getDetails) {
+				// This is a much more maintainable pattern. Maybe convert more extension logic to this getter/setter message design?
+				if (message.getDetails.termsFromSelection) {
+					sendResponse({ terms: getTermsFromSelection() });
+				}
+			}
 			if (message.extensionCommands) {
 				commands.splice(0);
 				message.extensionCommands.forEach(command => commands.push(command));
@@ -1796,7 +1809,7 @@ const beginHighlighting = (
 			if (bar) {
 				bar.classList[controlsInfo.highlightsShown ? "add" : "remove"](getSel(ElementClass.HIGHLIGHTS_SHOWN));
 			}
-			sendResponse(); // Mitigates manifest V3 bug which otherwise logs an error message
+			sendResponse({}); // Mitigates manifest V3 bug which otherwise logs an error message
 		});
 	};
 })()();


### PR DESCRIPTION
Previously, a 'highlight selection' message request would be ignored if the current research instance is persistent. This changes that behaviour, so that if the current selection encapsulates potential terms these are used to make a new research instance. Otherwise, the old instance is used as before.